### PR TITLE
Bump dependencies to begin using copycopter with rails 3.1.x-rc.

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -3,6 +3,9 @@ appraise "2.3" do
 end
 
 appraise "3.0" do
-  gem "rails", "~> 3.0.3"
+  gem "rails", "~> 3.0.9"
 end
 
+appraise "3.1" do
+  gem "rails", "~> 3.1.0.rc4"
+end

--- a/copycopter_client.gemspec
+++ b/copycopter_client.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.3.5"
   s.summary = "Client for the Copycopter content management service"
 
-  s.add_dependency 'i18n', '~> 0.5.0'
+  s.add_dependency 'i18n', '> 0.5.0'
   s.add_dependency 'json'
 end


### PR DESCRIPTION
Bump dependencies to begin using copycopter with rails 3.1.x-rc, as rails 3.1 depends on i18n 0.6.0.

Begin appraisals on 3.1.x.
