### PR TITLE
html_safe returns a ActiveSupport::SafeBuffer which needs to be convereted to a string if CopyCopter is used outside of a view

### DIFF
--- a/lib/copycopter_client/i18n_backend.rb
+++ b/lib/copycopter_client/i18n_backend.rb
@@ -25,7 +25,7 @@ module CopycopterClient
     def translate(locale, key, options = {})
       content = super(locale, key, options.merge(:fallback => true))
       if content.respond_to?(:html_safe)
-        content.html_safe
+        String.new(content.html_safe)
       else
         content
       end

--- a/lib/copycopter_client/i18n_backend.rb
+++ b/lib/copycopter_client/i18n_backend.rb
@@ -23,9 +23,10 @@ module CopycopterClient
     #
     # @return [Object] the translated key (usually a String)
     def translate(locale, key, options = {})
+      html_safely = options[:html_safely].blank? ? true : options[:html_safely]
       content = super(locale, key, options.merge(:fallback => true))
-      if content.respond_to?(:html_safe)
-        String.new(content.html_safe)
+      if content.respond_to?(:html_safe) && html_safely
+        content.html_safe
       else
         content
       end

--- a/spec/copycopter_client/i18n_backend_spec.rb
+++ b/spec/copycopter_client/i18n_backend_spec.rb
@@ -74,10 +74,16 @@ describe CopycopterClient::I18nBackend do
     cache['en.test.key'].should == default
   end
 
-  it "marks strings as html safe" do
+  it "marks strings as html safe by default" do
     cache['en.test.key'] = FakeHtmlSafeString.new("Hello")
     backend = build_backend
     backend.translate('en', 'test.key').should be_html_safe
+  end
+
+  it "doesn't mark strings as html safe if option set" do
+    cache['en.test.key'] = FakeHtmlSafeString.new("Hello")
+    backend = build_backend
+    backend.translate('en', 'test.key', :html_safely => false).should_not be_html_safe
   end
 
   it "looks up an array of defaults" do


### PR DESCRIPTION
We've struggled to find a way to easily write a failing test, but we were able to make this fail, then pass with one of our features.

The issue can reproduced when using using copycopter to pass strings to faraday (in our case this is used to call the facebook graph api). We were experiencing the following exception:

activesupport (3.1.1) lib/active_support/whiny_nil.rb:48:in `method_missing'
rack (1.3.5) lib/rack/utils.rb:257:in`bytesize'
faraday (0.7.5) lib/faraday/utils.rb:129:in `block in escape'
activesupport (3.1.1) lib/active_support/core_ext/string/output_safety.rb:142:in`gsub'
activesupport (3.1.1) lib/active_support/core_ext/string/output_safety.rb:142:in `gsub'
faraday (0.7.5) lib/faraday/utils.rb:128:in`escape'
faraday (0.7.5) lib/faraday/utils.rb:121:in `build_nested_query'
faraday (0.7.5) lib/faraday/utils.rb:115:in`block in build_nested_query'
faraday (0.7.5) lib/faraday/utils.rb:114:in `each'
faraday (0.7.5) lib/faraday/utils.rb:114:in`map'
faraday (0.7.5) lib/faraday/utils.rb:114:in `build_nested_query'
faraday (0.7.5) lib/faraday/request/url_encoded.rb:12:in`block in call'
faraday (0.7.5) lib/faraday/request/url_encoded.rb:22:in `match_content_type'
faraday (0.7.5) lib/faraday/request/url_encoded.rb:11:in`call'
faraday (0.7.5) lib/faraday/connection.rb:207:in `run_request'

We isolated the error to faraday-0.7.4/lib/faraday/utils.rb:129:

```
    # Be sure to URI escape '+' symbols to %2B. Otherwise, they get interpreted
    # as spaces.
    def escape(s)
      s.to_s.gsub(/([^a-zA-Z0-9_.-]+)/n) do
        '%' << $1.unpack('H2'*bytesize($1)).join('%').tap { |c| c.upcase! }
      end
    end
```

The gsub function was return nils instead of spaces for any long string with spaces in it. 
