### PR TITLE
Export blurbs to yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ Blurbs start out as draft copy, and won't be displayed in production environment
 
     rake copycopter:deploy
 
+Exporting
+---------
+
+Blurbs are cached in-memory while your Rails application is running. If you want to export all cached blurbs to a yml file for offline access, you can use the `copycopter:export` rake task:
+
+    rake copycopter:export
+
+The exported `copycopter.yml` will be located in `config/locales/`.
+
 Contributing
 ------------
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Blurbs are cached in-memory while your Rails application is running. If you want
 
     rake copycopter:export
 
-The exported `copycopter.yml` will be located in `config/locales/`.
+The exported yaml will be located at `config/locales/copycopter.yml`.
 
 Contributing
 ------------

--- a/lib/copycopter_client.rb
+++ b/lib/copycopter_client.rb
@@ -24,6 +24,12 @@ module CopycopterClient
     client.deploy
   end
 
+  # Issues a new export, returning yaml representation of blurb cache.
+  # This is called when the copycopter:export rake task is invoked.
+  def self.export
+    cache.export
+  end
+
   # Starts the polling process.
   def self.start_poller
     poller.start

--- a/lib/copycopter_client/cache.rb
+++ b/lib/copycopter_client/cache.rb
@@ -43,6 +43,27 @@ module CopycopterClient
       lock { @blurbs.keys }
     end
 
+    # Yaml representation of all blurbs
+    # @return [String] yaml
+    def export
+      keys = {}
+      lock do
+        @blurbs.each do |blurb_key, value|
+          current = keys
+          yaml_keys = blurb_key.split('.')
+
+          0.upto(yaml_keys.size - 2) do |i|
+            key = yaml_keys[i]
+            current[key] ||= {}
+            current = current[key]
+          end
+
+          current[yaml_keys.last] = value
+        end
+      end
+      keys.to_yaml unless keys.size < 1
+    end
+
     # Waits until the first download has finished.
     def wait_for_download
       if pending?

--- a/lib/copycopter_client/cache.rb
+++ b/lib/copycopter_client/cache.rb
@@ -54,7 +54,8 @@ module CopycopterClient
 
           0.upto(yaml_keys.size - 2) do |i|
             key = yaml_keys[i]
-            current[key] ||= {}
+            # Overwrite en.key with en.sub.key
+            current[key] = {} unless current[key].class == Hash
             current = current[key]
           end
 

--- a/lib/tasks/copycopter_client_tasks.rake
+++ b/lib/tasks/copycopter_client_tasks.rake
@@ -4,4 +4,17 @@ namespace :copycopter do
     CopycopterClient.deploy
     puts "Successfully marked all blurbs as published."
   end
+
+  desc "Export Copycopter blurbs to yaml."
+  task :export => :environment do
+    CopycopterClient.cache.sync
+
+    if yml = CopycopterClient.export
+      PATH = "config/locales/copycopter.yml"
+      File.new("#{Rails.root}/#{PATH}", 'w').write(yml)
+      puts "Successfully exported blurbs to #{PATH}."
+    else
+      puts "No blurbs have been cached."
+    end
+  end
 end

--- a/spec/copycopter_client/cache_spec.rb
+++ b/spec/copycopter_client/cache_spec.rb
@@ -215,7 +215,7 @@ describe CopycopterClient::Cache do
 
     let(:save_blurbs) {}
 
-    it "Can be invoked from the top-level constant" do
+    it "can be invoked from the top-level constant" do
       CopycopterClient.configure do |config|
         config.cache = @cache
       end
@@ -226,10 +226,8 @@ describe CopycopterClient::Cache do
       @cache.should have_received(:export)
     end
 
-    context "with no blurb keys" do
-      it "returns no yaml" do
-        @cache.export.should == nil
-      end
+    it "returns no yaml with no blurb keys" do
+      @cache.export.should == nil
     end
 
     context "with single-level blurb keys" do

--- a/spec/copycopter_client/cache_spec.rb
+++ b/spec/copycopter_client/cache_spec.rb
@@ -237,10 +237,9 @@ describe CopycopterClient::Cache do
       end
 
       it "returns blurbs as yaml" do
-        @cache.export.should ==
-          "---"                         + "\n" +
-          "key: test value"             + "\n" +
-          "other_key: other test value" + "\n"
+        exported = YAML.load(@cache.export)
+        exported['key'].should == 'test value'
+        exported['other_key'].should == 'other test value'
       end
     end
 
@@ -252,29 +251,22 @@ describe CopycopterClient::Cache do
       end
 
       it "returns blurbs as yaml" do
-        @cache.export.should ==
-          "---"                                + "\n" +
-          "en:"                                + "\n" +
-          "  test:"                            + "\n" +
-          "    key: en test value"             + "\n" +
-          "    other_key: en other test value" + "\n" +
-          "fr:"                                + "\n" +
-          "  test:"                            + "\n" +
-          "    key: fr test value"             + "\n"
+        exported = YAML.load(@cache.export)
+        exported['en']['test']['key'].should == 'en test value'
+        exported['en']['test']['other_key'].should == 'en other test value'
+        exported['fr']['test']['key'].should == 'fr test value'
       end
     end
 
     context "with conflicting blurb keys" do
       let(:save_blurbs) do
-        client['en.test.key'] = 'test value'
-        client['en.test']     = 'other test value'
+        client['en.test']     = 'test value'
+        client['en.test.key'] = 'other test value'
       end
 
       it "retains the new key" do
-        @cache.export.should ==
-          "---"                      + "\n" +
-          "en:"                      + "\n" +
-          "  test: other test value" + "\n"
+        exported = YAML.load(@cache.export)
+        exported['en']['test']['key'].should == 'other test value'
       end
     end
   end


### PR DESCRIPTION
Add export to Copycopter cache with accompanying rake task and readme.
