### PR TITLE
Force encoding of blurbs download

### DIFF
--- a/lib/copycopter_client/client.rb
+++ b/lib/copycopter_client/client.rb
@@ -50,7 +50,7 @@ module CopycopterClient
 
         if check response
           log 'Downloaded translations'
-          yield JSON.parse(response.body)
+          yield JSON.parse(response.body.force_encoding('UTF-8'))
         else
           log 'No new translations'
         end


### PR DESCRIPTION
In our case the JSON::parse heuristics were not correctly recognizing the encoding of the response body. The simplest way to remedy this is to explicitly mark the body as being in UTF-8.

A more robust approach would be to check the response's content-type header and extract the encoding from there. I would give this a try _if_ the copycopter server is able to set the encoding to anything else than UTF-8. Otherwise I would just leave it hardcoded as is.
