### PR TITLE
I18n Version Requirement Change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    copycopter_client (2.0.0)
-      i18n (>= 0.5.0)
+    copycopter_client (2.0.1)
+      i18n
       json
 
 GEM

--- a/copycopter_client.gemspec
+++ b/copycopter_client.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'copycopter_client/version'
 
 Gem::Specification.new do |s|
-  s.add_dependency 'i18n', '>= 0.5.0'
+  s.add_dependency 'i18n'
   s.add_dependency 'json'
   s.add_development_dependency 'appraisal', '~> 0.4'
   s.add_development_dependency 'aruba', '~> 0.3.2'


### PR DESCRIPTION
The i18n version requirement was causing a conflict with the mail gem and older versions (3.0) of Rails. I removed the gem version requirement and played around with it, finding no issues with reverting to i18n 0.4.x.
