### PR TITLE
Fixing a bug about string and symbol comparison

### DIFF
--- a/lib/copycopter_client/i18n_backend.rb
+++ b/lib/copycopter_client/i18n_backend.rb
@@ -34,7 +34,7 @@ module CopycopterClient
     # Returns locales availabile for this Copycopter project.
     # @return [Array<String>] available locales
     def available_locales
-      cached_locales = cache.keys.map { |key| key.split('.').first }
+      cached_locales = cache.keys.map { |key| key.split('.').first.to_sym }
       (cached_locales + super).uniq.map { |locale| locale.to_sym }
     end
 

--- a/spec/copycopter_client/i18n_backend_spec.rb
+++ b/spec/copycopter_client/i18n_backend_spec.rb
@@ -50,6 +50,14 @@ describe CopycopterClient::I18nBackend do
     subject.available_locales.should =~ [:en, :es, :fr]
   end
 
+  it "handles symbol locales from i18n gem" do
+    YAML.stubs(:load_file => { :en => { 'key' => 'value' } })
+    I18n.stubs(:load_path => ["test.yml"])
+
+    cache['en.key'] = ''
+
+    subject.available_locales.should =~ [:en]
+  end
   it "queues missing keys with default" do
     default = 'default value'
 


### PR DESCRIPTION
Hey,
I think the spec + fix are pretty self-explanatory.
happened when I tried showing the available locales for the user to chose, they appeared twice.

Thanks
