### PR TITLE
Added option to only send specified locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 Copycopter Client
 =================
 
-[![Build Status](https://secure.travis-ci.org/copycopter/copycopter-ruby-client.png?branch=master)](http://travis-ci.org/copycopter/copycopter-ruby-client)
-
 This is the Ruby on Rails client for
-[Copycopter](https://github.com/copycopter/copycopter-server).
+[Copycopter](https://github.com/copycopter/copycopter-server) with the addition to just send locales that are set as active to the copycopter server.
 
 It uses I18n to access copy and translations from a Copycopter project.
 
@@ -24,6 +22,7 @@ In your `config/initializers/copycopter.rb`:
     CopycopterClient.configure do |config|
       config.api_key = 'YOUR API KEY HERE'
       config.host = 'your-copycopter-server.herokuapp.com'
+      config.active_locales = [:en,:de]
     end
 
 The API key is on the project page. See `CopycopterClient::Configuration` for

--- a/lib/copycopter_client/client.rb
+++ b/lib/copycopter_client/client.rb
@@ -27,7 +27,7 @@ module CopycopterClient
     # @option options [String] :ca_file path to root certificate file for ssl verification
     def initialize(options)
       [:api_key, :host, :port, :public, :http_read_timeout,
-        :http_open_timeout, :secure, :logger, :ca_file].each do |option|
+        :http_open_timeout, :secure, :logger, :ca_file, :active_locales].each do |option|
         instance_variable_set "@#{option}", options[option]
       end
     end
@@ -83,7 +83,7 @@ module CopycopterClient
     private
 
     attr_reader :host, :port, :api_key, :http_read_timeout,
-      :http_open_timeout, :secure, :logger, :ca_file
+      :http_open_timeout, :secure, :logger, :ca_file, :active_locales
 
     def public?
       @public

--- a/lib/copycopter_client/configuration.rb
+++ b/lib/copycopter_client/configuration.rb
@@ -12,7 +12,7 @@ module CopycopterClient
   class Configuration
 
     # These options will be present in the Hash returned by {#to_hash}.
-    OPTIONS = [:api_key, :development_environments, :environment_name, :host,
+    OPTIONS = [:api_key, :development_environments, :environment_name, :active_locales, :host,
         :http_open_timeout, :http_read_timeout, :client_name, :client_url,
         :client_version, :port, :protocol, :proxy_host, :proxy_pass,
         :proxy_port, :proxy_user, :secure, :polling_delay, :logger,
@@ -56,6 +56,9 @@ module CopycopterClient
 
     # @return [String] The name of the environment the application is running in
     attr_accessor :environment_name
+
+    # @return [Array<String>] A list of locales that should be sent to the server
+    attr_accessor :active_locales
 
     # @return [String] The name of the client library being used to send notifications (defaults to +Copycopter Client+)
     attr_accessor :client_name
@@ -102,6 +105,7 @@ module CopycopterClient
       self.polling_delay = 300
       self.secure = false
       self.test_environments = %w(test cucumber)
+      self.active_locales = %w(:en)
       @applied = false
     end
 

--- a/lib/copycopter_client/i18n_backend.rb
+++ b/lib/copycopter_client/i18n_backend.rb
@@ -34,6 +34,7 @@ module CopycopterClient
     # Returns locales availabile for this Copycopter project.
     # @return [Array<String>] available locales
     def available_locales
+      super
       cached_locales = cache.keys.map { |key| key.split('.').first }
       (cached_locales + super).uniq.map { |locale| locale.to_sym }
     end
@@ -48,7 +49,7 @@ module CopycopterClient
     # @param [Hash] options unused part of the I18n API
     def store_translations(locale, data, options = {})
       super
-      store_item(locale, data)
+      store_item(locale, data) if CopycopterClient.configuration.active_locales.include?(locale.to_sym)
     end
 
     private


### PR DESCRIPTION
I had the problem that with spree it was loading a huge amount of locales, it took ages to send everything to copycopter and the export yml file had 3MB. 
Probably shouldn't have modified the readme file ... but wanted to have it documented. 
