### PR TITLE
Sub-URI support

### DIFF
--- a/lib/copycopter_client/client.rb
+++ b/lib/copycopter_client/client.rb
@@ -26,7 +26,7 @@ module CopycopterClient
     # @option options [Logger] :logger where to log transactions
     # @option options [String] :ca_file path to root certificate file for ssl verification
     def initialize(options)
-      [:api_key, :host, :port, :public, :http_read_timeout,
+      [:api_key, :host, :path, :port, :public, :http_read_timeout,
         :http_open_timeout, :secure, :logger, :ca_file].each do |option|
         instance_variable_set "@#{option}", options[option]
       end
@@ -82,7 +82,7 @@ module CopycopterClient
 
     private
 
-    attr_reader :host, :port, :api_key, :http_read_timeout,
+    attr_reader :host, :path, :port, :api_key, :http_read_timeout,
       :http_open_timeout, :secure, :logger, :ca_file
 
     def public?
@@ -90,7 +90,7 @@ module CopycopterClient
     end
 
     def uri(resource)
-      "/api/v2/projects/#{api_key}/#{resource}"
+      "#{path}/api/v2/projects/#{api_key}/#{resource}"
     end
 
     def download_resource

--- a/lib/copycopter_client/configuration.rb
+++ b/lib/copycopter_client/configuration.rb
@@ -12,7 +12,7 @@ module CopycopterClient
   class Configuration
 
     # These options will be present in the Hash returned by {#to_hash}.
-    OPTIONS = [:api_key, :development_environments, :environment_name, :host,
+    OPTIONS = [:api_key, :development_environments, :environment_name, :host, :path,
         :http_open_timeout, :http_read_timeout, :client_name, :client_url,
         :client_version, :port, :protocol, :proxy_host, :proxy_pass,
         :proxy_port, :proxy_user, :secure, :polling_delay, :logger,
@@ -23,6 +23,9 @@ module CopycopterClient
 
     # @return [String] The host to connect to (defaults to +copycopter.com+).
     attr_accessor :host
+
+    # @return [String] A sub-URI/relative path for all requests (defaults to empty string).
+    attr_accessor :path
 
     # @return [Fixnum] The port on which your Copycopter server runs (defaults to +443+ for secure connections, +80+ for insecure connections).
     attr_accessor :port
@@ -96,6 +99,7 @@ module CopycopterClient
       self.client_version = VERSION
       self.development_environments = %w(development staging)
       self.host = 'copycopter.com'
+      self.path = ''
       self.http_open_timeout = 2
       self.http_read_timeout = 5
       self.logger = Logger.new($stdout)

--- a/spec/copycopter_client/configuration_spec.rb
+++ b/spec/copycopter_client/configuration_spec.rb
@@ -35,6 +35,7 @@ describe CopycopterClient::Configuration do
   it { should have_config_option(:client_url).overridable.default('https://rubygems.org/gems/copycopter_client') }
   it { should have_config_option(:secure).overridable.default(false) }
   it { should have_config_option(:host).overridable.default('copycopter.com') }
+  it { should have_config_option(:path).overridable.default('') }
   it { should have_config_option(:http_open_timeout).overridable.default(2) }
   it { should have_config_option(:http_read_timeout).overridable.default(5) }
   it { should have_config_option(:port).overridable }


### PR DESCRIPTION
Add a configuration option (`path`) for prefixing API requests to copycopter server installations which do not respond to root-level (`/`) requests and are instead hosted at a sub-URI like `/copycopter`.
