### PR TITLE
Updated README.md to include environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ In your `config/initializers/copycopter.rb`:
     CopycopterClient.configure do |config|
       config.api_key = 'YOUR API KEY HERE'
       config.host = 'your-copycopter-server.herokuapp.com'
+      config.environment_name = Rails.env
     end
 
 The API key is on the project page. See `CopycopterClient::Configuration` for


### PR DESCRIPTION
Updated README.md to include a the environment in the configuration without which it wouldn't update the text in the development environment when the "draft" text was saved on the server.
